### PR TITLE
Remove the unecessary file lock, attempt to rename before copying.

### DIFF
--- a/candle-hub/Cargo.toml
+++ b/candle-hub/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 dirs = "5.0.1"
-fs2 = "0.4.3"
 rand = "0.8.5"
 thiserror = "1.0.40"
 futures = { version = "0.3.28", optional = true }


### PR DESCRIPTION
Removnig the file lock causing issues on windows.

We're creating the file later instead (if concurrent downloads are happening the `create` should fail). and `rename` instead of `copy` for faster movement.