### PR TITLE
Simplify the dtype matchings in the cuda backend

### DIFF
--- a/candle-core/examples/llama/main.rs
+++ b/candle-core/examples/llama/main.rs
@@ -487,6 +487,7 @@ fn main() -> Result<()> {
     let mut rng = thread_rng();
     let start_gen = std::time::Instant::now();
     for index in 0..args.sample_len {
+        let start_gen = std::time::Instant::now();
         let ctxt = &tokens[tokens.len().saturating_sub(CONTEXT_SIZE)..];
         let input = Tensor::new(ctxt, &device)?;
         let logits = llama.forward(&input, &freqs_cis)?;
@@ -496,6 +497,7 @@ fn main() -> Result<()> {
         let next_token = distr.sample(&mut rng) as u32;
         tokens.push(next_token);
         new_tokens.push(next_token);
+        println!("> {:?}", start_gen.elapsed());
         println!(
             "{} token: {} '{}'",
             index + 1,

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -44,7 +44,7 @@ impl CudaDevice {
 pub struct CudaStorage;
 
 impl CudaStorage {
-    pub fn try_clone(&self) -> Result<Self> {
+    pub fn try_clone(&self, _: &Layout) -> Result<Self> {
         Err(Error::NotCompiledWithCudaSupport)
     }
 

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -43,11 +43,8 @@ pub(crate) enum Op {
 
 pub(crate) trait UnaryOp {
     const NAME: &'static str;
-    const KERNEL_BF16: &'static str;
-    const KERNEL_F16: &'static str;
-    const KERNEL_F32: &'static str;
-    const KERNEL_F64: &'static str;
-    const KERNEL_U32: &'static str;
+    const KERNEL: &'static str;
+    const V: Self;
     fn bf16(v1: bf16) -> bf16;
     fn f16(v1: f16) -> f16;
     fn f32(v1: f32) -> f32;
@@ -121,11 +118,8 @@ macro_rules! unary_op {
     ($op: ident, $name: literal, $a: ident, $e: expr) => {
         impl UnaryOp for $op {
             const NAME: &'static str = $name;
-            const KERNEL_BF16: &'static str = concat!("u", $name, "_bf16");
-            const KERNEL_F16: &'static str = concat!("u", $name, "_f16");
-            const KERNEL_F32: &'static str = concat!("u", $name, "_f32");
-            const KERNEL_F64: &'static str = concat!("u", $name, "_f64");
-            const KERNEL_U32: &'static str = concat!("u", $name, "_u32");
+            const KERNEL: &'static str = concat!("u", $name);
+            const V: Self = $op;
             fn bf16($a: bf16) -> bf16 {
                 $e
             }
@@ -158,6 +152,7 @@ unary_op!(Sqrt, "sqrt", v, v.sqrt());
 /// <https://en.wikipedia.org/wiki/Activation_function#Comparison_of_activation_functions>
 impl UnaryOp for Gelu {
     const NAME: &'static str = "gelu";
+    const V: Self = Gelu;
     fn bf16(v: bf16) -> bf16 {
         bf16::from_f32_const(0.5)
             * v
@@ -191,20 +186,13 @@ impl UnaryOp for Gelu {
     fn u32(_: u32) -> u32 {
         0
     }
-    const KERNEL_BF16: &'static str = "ugelu_bf16";
-    const KERNEL_F16: &'static str = "ugelu_f16";
-    const KERNEL_F32: &'static str = "ugelu_f32";
-    const KERNEL_F64: &'static str = "ugelu_f64";
-    const KERNEL_U32: &'static str = "ugelu_u32";
+    const KERNEL: &'static str = "ugelu";
 }
 
 impl UnaryOp for Relu {
     const NAME: &'static str = "relu";
-    const KERNEL_BF16: &'static str = "urelu_bf16";
-    const KERNEL_F16: &'static str = "urelu_f16";
-    const KERNEL_F32: &'static str = "urelu_f32";
-    const KERNEL_F64: &'static str = "urelu_f64";
-    const KERNEL_U32: &'static str = "urelu_u32";
+    const KERNEL: &'static str = "urelu";
+    const V: Self = Relu;
     fn bf16(v: bf16) -> bf16 {
         v.max(bf16::ZERO)
     }

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -54,11 +54,8 @@ pub(crate) trait UnaryOp {
 
 pub(crate) trait BinaryOp {
     const NAME: &'static str;
-    const KERNEL_BF16: &'static str;
-    const KERNEL_F16: &'static str;
-    const KERNEL_F32: &'static str;
-    const KERNEL_F64: &'static str;
-    const KERNEL_U32: &'static str;
+    const KERNEL: &'static str;
+    const V: Self;
     fn bf16(v1: bf16, v2: bf16) -> bf16;
     fn f16(v1: f16, v2: f16) -> f16;
     fn f32(v1: f32, v2: f32) -> f32;
@@ -85,11 +82,8 @@ macro_rules! bin_op {
     ($op:ident, $name: literal, $e: expr) => {
         impl BinaryOp for $op {
             const NAME: &'static str = $name;
-            const KERNEL_BF16: &'static str = concat!("b", $name, "_bf16");
-            const KERNEL_F16: &'static str = concat!("b", $name, "_f16");
-            const KERNEL_F32: &'static str = concat!("b", $name, "_f32");
-            const KERNEL_F64: &'static str = concat!("b", $name, "_f64");
-            const KERNEL_U32: &'static str = concat!("b", $name, "_u32");
+            const KERNEL: &'static str = concat!("b", $name);
+            const V: Self = $op;
             fn bf16(v1: bf16, v2: bf16) -> bf16 {
                 $e(v1, v2)
             }

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -9,11 +9,11 @@ pub enum Storage {
 }
 
 impl Storage {
-    pub fn try_clone(&self) -> Result<Self> {
+    pub fn try_clone(&self, layout: &Layout) -> Result<Self> {
         match self {
             Self::Cpu(storage) => Ok(Self::Cpu(storage.clone())),
             Self::Cuda(storage) => {
-                let storage = storage.try_clone()?;
+                let storage = storage.try_clone(layout)?;
                 Ok(Self::Cuda(storage))
             }
         }

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -709,7 +709,7 @@ impl Tensor {
     pub fn copy(&self) -> Result<Tensor> {
         let tensor_ = Tensor_ {
             id: TensorId::new(),
-            storage: Arc::new(self.storage.try_clone()?),
+            storage: Arc::new(self.storage.try_clone(self.layout())?),
             layout: self.layout.clone(),
             op: None, // TODO
             is_variable: false,


### PR DESCRIPTION
Add some map operation so that the dtype matching code is factored out and only required for very custom ops (cast, matmul).