### PR TITLE
Fixing unsafe slow load (memcpy).

### DIFF
--- a/candle-core/src/safetensors.rs
+++ b/candle-core/src/safetensors.rs
@@ -71,6 +71,8 @@ fn convert_<T: WithDType>(view: st::TensorView<'_>, device: &Device) -> Result<T
         let data: &[T] = unsafe { std::slice::from_raw_parts(v.as_ptr() as *const T, elem_count) };
         Tensor::from_slice(data, view.shape(), device)
     } else {
+        // XXX: We need to specify `T` here, otherwise the compiler will infer u8 because of the following cast
+        // Making this vector too small to fit a full f16/f32/f64 weights, resulting in out-of-bounds access
         let mut c: Vec<T> = Vec::with_capacity(elem_count);
         // SAFETY: We just created c, so the allocated memory is necessarily
         // contiguous and non overlapping with the view's data.

--- a/candle-core/src/safetensors.rs
+++ b/candle-core/src/safetensors.rs
@@ -71,7 +71,7 @@ fn convert_<T: WithDType>(view: st::TensorView<'_>, device: &Device) -> Result<T
         let data: &[T] = unsafe { std::slice::from_raw_parts(v.as_ptr() as *const T, elem_count) };
         Tensor::from_slice(data, view.shape(), device)
     } else {
-        let mut c = Vec::with_capacity(elem_count);
+        let mut c: Vec<T> = Vec::with_capacity(elem_count);
         // SAFETY: We just created c, so the allocated memory is necessarily
         // contiguous and non overlapping with the view's data.
         // We're downgrading the `c` pointer from T to u8, which removes alignment


### PR DESCRIPTION
- Without the annotation, I think the rust compiler assumes it's all u8.

It did segfault trying to load `Roberta`.