### PR TITLE
Move the var-builder in a central place.

### DIFF
--- a/candle-examples/examples/bert/main.rs
+++ b/candle-examples/examples/bert/main.rs
@@ -4,72 +4,14 @@
 extern crate intel_mkl_src;
 
 use anyhow::{anyhow, Error as E, Result};
-use candle::{safetensors::SafeTensors, DType, Device, Shape, Tensor};
+use candle::{DType, Device, Tensor};
 use candle_hub::{api::sync::Api, Cache, Repo, RepoType};
-use candle_nn::{Embedding, LayerNorm, Linear};
+use candle_nn::{Embedding, LayerNorm, Linear, VarBuilder};
 use clap::Parser;
 use serde::Deserialize;
-use std::collections::HashMap;
 use tokenizers::{PaddingParams, Tokenizer};
 
 const DTYPE: DType = DType::F32;
-
-struct VarBuilder<'a> {
-    safetensors: Option<(HashMap<String, usize>, Vec<SafeTensors<'a>>)>,
-    dtype: DType,
-    device: Device,
-}
-
-impl<'a> VarBuilder<'a> {
-    pub fn from_safetensors(
-        safetensors: Vec<SafeTensors<'a>>,
-        dtype: DType,
-        device: Device,
-    ) -> Self {
-        let mut routing = HashMap::new();
-        for (index, sf) in safetensors.iter().enumerate() {
-            for k in sf.names() {
-                routing.insert(k.to_string(), index);
-            }
-        }
-        Self {
-            safetensors: Some((routing, safetensors)),
-            device,
-            dtype,
-        }
-    }
-
-    pub fn zeros(dtype: DType, device: Device) -> Self {
-        Self {
-            safetensors: None,
-            device,
-            dtype,
-        }
-    }
-
-    pub fn get<S: Into<Shape>>(&self, s: S, tensor_name: &str) -> candle::Result<Tensor> {
-        let s: Shape = s.into();
-        match &self.safetensors {
-            None => Tensor::zeros(s, self.dtype, &self.device),
-            Some((routing, safetensors)) => {
-                // Unwrap or 0  just to let the proper error flow.
-                let index = routing.get(tensor_name).unwrap_or(&0);
-                let tensor = safetensors[*index]
-                    .tensor(tensor_name, &self.device)?
-                    .to_dtype(self.dtype)?;
-                if *tensor.shape() != s {
-                    let msg = format!("shape mismatch for {tensor_name}");
-                    Err(candle::Error::UnexpectedShape {
-                        msg,
-                        expected: s,
-                        got: tensor.shape().clone(),
-                    })?
-                }
-                Ok(tensor)
-            }
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -633,7 +575,7 @@ impl Args {
 
         let weights = unsafe { candle::safetensors::MmapedFile::new(weights_filename)? };
         let weights = weights.deserialize()?;
-        let vb = VarBuilder::from_safetensors(vec![weights], DTYPE, device);
+        let vb = VarBuilder::from_safetensors(vec![weights], DTYPE, &device);
         let model = BertModel::load(&vb, &config)?;
         Ok((model, tokenizer))
     }

--- a/candle-examples/examples/falcon/main.rs
+++ b/candle-examples/examples/falcon/main.rs
@@ -7,12 +7,13 @@ extern crate intel_mkl_src;
 use anyhow::{Error as E, Result};
 use candle::{DType, Device, Tensor, D};
 use candle_hub::{api::sync::Api, Repo, RepoType};
+use candle_nn::VarBuilder;
 use clap::Parser;
 use rand::{distributions::Distribution, SeedableRng};
 use tokenizers::Tokenizer;
 
 mod model;
-use model::{Config, Falcon, VarBuilder};
+use model::{Config, Falcon};
 
 #[cfg(feature = "mkl")]
 const DTYPE: DType = DType::F32;

--- a/candle-examples/examples/falcon/model.rs
+++ b/candle-examples/examples/falcon/model.rs
@@ -1,66 +1,8 @@
 use anyhow::Result;
-use candle::{safetensors::SafeTensors, DType, Device, Shape, Tensor, D};
-use candle_nn::{Embedding, LayerNorm, Linear};
-use std::collections::HashMap;
+use candle::{DType, Device, Tensor, D};
+use candle_nn::{Embedding, LayerNorm, Linear, VarBuilder};
 
 const MAX_SEQ_LEN: usize = 5000;
-
-pub struct VarBuilder<'a> {
-    safetensors: Option<(HashMap<String, usize>, Vec<SafeTensors<'a>>)>,
-    dtype: DType,
-    device: Device,
-}
-
-impl<'a> VarBuilder<'a> {
-    pub fn from_safetensors(
-        safetensors: Vec<SafeTensors<'a>>,
-        dtype: DType,
-        device: &Device,
-    ) -> Self {
-        let mut routing = HashMap::new();
-        for (index, sf) in safetensors.iter().enumerate() {
-            for k in sf.names() {
-                routing.insert(k.to_string(), index);
-            }
-        }
-        Self {
-            safetensors: Some((routing, safetensors)),
-            device: device.clone(),
-            dtype,
-        }
-    }
-
-    pub fn zeros(dtype: DType, device: &Device) -> Self {
-        Self {
-            safetensors: None,
-            device: device.clone(),
-            dtype,
-        }
-    }
-
-    pub fn get<S: Into<Shape>>(&self, s: S, tensor_name: &str) -> candle::Result<Tensor> {
-        let s: Shape = s.into();
-        match &self.safetensors {
-            None => Tensor::zeros(s, self.dtype, &self.device),
-            Some((routing, safetensors)) => {
-                // Unwrap or 0  just to let the proper error flow.
-                let index = routing.get(tensor_name).unwrap_or(&0);
-                let tensor = safetensors[*index]
-                    .tensor(tensor_name, &self.device)?
-                    .to_dtype(self.dtype)?;
-                if *tensor.shape() != s {
-                    let msg = format!("shape mismatch for {tensor_name}");
-                    Err(candle::Error::UnexpectedShape {
-                        msg,
-                        expected: s,
-                        got: tensor.shape().clone(),
-                    })?
-                }
-                Ok(tensor)
-            }
-        }
-    }
-}
 
 fn linear(size1: usize, size2: usize, bias: bool, p: &str, vb: &VarBuilder) -> Result<Linear> {
     let weight = vb.get((size2, size1), &format!("{p}.weight"))?;

--- a/candle-examples/examples/musicgen/nn.rs
+++ b/candle-examples/examples/musicgen/nn.rs
@@ -1,68 +1,11 @@
 #![allow(dead_code)]
 
 use anyhow::Result;
-use candle::{safetensors::SafeTensors, DType, Device, Shape, Tensor};
-use std::collections::HashMap;
+use candle::Tensor;
 
 const MAX_SEQ_LEN: usize = 5000;
 
-pub struct VarBuilder<'a> {
-    safetensors: Option<(HashMap<String, usize>, Vec<SafeTensors<'a>>)>,
-    dtype: DType,
-    device: Device,
-}
-
-impl<'a> VarBuilder<'a> {
-    pub fn from_safetensors(
-        safetensors: Vec<SafeTensors<'a>>,
-        dtype: DType,
-        device: &Device,
-    ) -> Self {
-        let mut routing = HashMap::new();
-        for (index, sf) in safetensors.iter().enumerate() {
-            for k in sf.names() {
-                routing.insert(k.to_string(), index);
-            }
-        }
-        Self {
-            safetensors: Some((routing, safetensors)),
-            device: device.clone(),
-            dtype,
-        }
-    }
-
-    pub fn zeros(dtype: DType, device: &Device) -> Self {
-        Self {
-            safetensors: None,
-            device: device.clone(),
-            dtype,
-        }
-    }
-
-    pub fn get<S: Into<Shape>>(&self, s: S, tensor_name: &str) -> candle::Result<Tensor> {
-        let s: Shape = s.into();
-        match &self.safetensors {
-            None => Tensor::zeros(s, self.dtype, &self.device),
-            Some((routing, safetensors)) => {
-                // Unwrap or 0  just to let the proper error flow.
-                let index = routing.get(tensor_name).unwrap_or(&0);
-                let tensor = safetensors[*index]
-                    .tensor(tensor_name, &self.device)?
-                    .to_dtype(self.dtype)?;
-                if *tensor.shape() != s {
-                    let msg = format!("shape mismatch for {tensor_name}");
-                    Err(candle::Error::UnexpectedShape {
-                        msg,
-                        expected: s,
-                        got: tensor.shape().clone(),
-                    })?
-                }
-                Ok(tensor)
-            }
-        }
-    }
-}
-
+pub type VarBuilder<'a> = candle_nn::VarBuilder<'a>;
 pub type Linear = candle_nn::Linear;
 
 pub fn linear(size1: usize, size2: usize, bias: bool, p: &str, vb: &VarBuilder) -> Result<Linear> {

--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -12,13 +12,14 @@ extern crate intel_mkl_src;
 use anyhow::{Error as E, Result};
 use candle::{DType, Device, Tensor};
 use candle_hub::{api::sync::Api, Repo, RepoType};
+use candle_nn::VarBuilder;
 use clap::Parser;
 use rand::{distributions::Distribution, SeedableRng};
 use tokenizers::Tokenizer;
 
 mod audio;
 mod model;
-use model::{Config, VarBuilder, Whisper};
+use model::{Config, Whisper};
 
 const DTYPE: DType = DType::F32;
 

--- a/candle-examples/examples/whisper/model.rs
+++ b/candle-examples/examples/whisper/model.rs
@@ -1,67 +1,9 @@
 // We use anyhow rather than candle errors as it provides better support for getting the backtrace
 // back when using RUST_LIB_BACKTRACE=1.
 use anyhow::Result;
-use candle::{safetensors::SafeTensors, DType, Device, Shape, Tensor};
-use candle_nn::{Conv1d, Conv1dConfig, Embedding, LayerNorm, Linear};
+use candle::{Device, Tensor};
+use candle_nn::{Conv1d, Conv1dConfig, Embedding, LayerNorm, Linear, VarBuilder};
 use serde::Deserialize;
-use std::collections::HashMap;
-
-pub struct VarBuilder<'a> {
-    safetensors: Option<(HashMap<String, usize>, Vec<SafeTensors<'a>>)>,
-    dtype: DType,
-    device: Device,
-}
-
-impl<'a> VarBuilder<'a> {
-    pub fn from_safetensors(
-        safetensors: Vec<SafeTensors<'a>>,
-        dtype: DType,
-        device: &Device,
-    ) -> Self {
-        let mut routing = HashMap::new();
-        for (index, sf) in safetensors.iter().enumerate() {
-            for k in sf.names() {
-                routing.insert(k.to_string(), index);
-            }
-        }
-        Self {
-            safetensors: Some((routing, safetensors)),
-            device: device.clone(),
-            dtype,
-        }
-    }
-
-    pub fn zeros(dtype: DType, device: Device) -> Self {
-        Self {
-            safetensors: None,
-            device,
-            dtype,
-        }
-    }
-
-    pub fn get<S: Into<Shape>>(&self, s: S, tensor_name: &str) -> candle::Result<Tensor> {
-        let s: Shape = s.into();
-        match &self.safetensors {
-            None => Tensor::zeros(s, self.dtype, &self.device),
-            Some((routing, safetensors)) => {
-                // Unwrap or 0  just to let the proper error flow.
-                let index = routing.get(tensor_name).unwrap_or(&0);
-                let tensor = safetensors[*index]
-                    .tensor(tensor_name, &self.device)?
-                    .to_dtype(self.dtype)?;
-                if *tensor.shape() != s {
-                    let msg = format!("shape mismatch for {tensor_name}");
-                    Err(candle::Error::UnexpectedShape {
-                        msg,
-                        expected: s,
-                        got: tensor.shape().clone(),
-                    })?
-                }
-                Ok(tensor)
-            }
-        }
-    }
-}
 
 // The names in comments correspond to the original implementation:
 // https://github.com/openai/whisper/blob/f572f2161ba831bae131364c3bffdead7af6d210/whisper/model.py#L17

--- a/candle-nn/src/lib.rs
+++ b/candle-nn/src/lib.rs
@@ -5,9 +5,11 @@ mod conv;
 mod embedding;
 mod layer_norm;
 mod linear;
+mod var_builder;
 
 pub use activation::Activation;
 pub use conv::{Conv1d, Conv1dConfig};
 pub use embedding::Embedding;
 pub use layer_norm::LayerNorm;
 pub use linear::Linear;
+pub use var_builder::VarBuilder;

--- a/candle-nn/src/var_builder.rs
+++ b/candle-nn/src/var_builder.rs
@@ -1,0 +1,59 @@
+use candle::{safetensors::SafeTensors, DType, Device, Shape, Tensor};
+use std::collections::HashMap;
+
+pub struct VarBuilder<'a> {
+    safetensors: Option<(HashMap<String, usize>, Vec<SafeTensors<'a>>)>,
+    pub dtype: DType,
+    pub device: Device,
+}
+
+impl<'a> VarBuilder<'a> {
+    pub fn from_safetensors(
+        safetensors: Vec<SafeTensors<'a>>,
+        dtype: DType,
+        device: &Device,
+    ) -> Self {
+        let mut routing = HashMap::new();
+        for (index, sf) in safetensors.iter().enumerate() {
+            for k in sf.names() {
+                routing.insert(k.to_string(), index);
+            }
+        }
+        Self {
+            safetensors: Some((routing, safetensors)),
+            device: device.clone(),
+            dtype,
+        }
+    }
+
+    pub fn zeros(dtype: DType, device: Device) -> Self {
+        Self {
+            safetensors: None,
+            device,
+            dtype,
+        }
+    }
+
+    pub fn get<S: Into<Shape>>(&self, s: S, tensor_name: &str) -> candle::Result<Tensor> {
+        let s: Shape = s.into();
+        match &self.safetensors {
+            None => Tensor::zeros(s, self.dtype, &self.device),
+            Some((routing, safetensors)) => {
+                // Unwrap or 0 just to let the proper error flow.
+                let index = routing.get(tensor_name).unwrap_or(&0);
+                let tensor = safetensors[*index]
+                    .tensor(tensor_name, &self.device)?
+                    .to_dtype(self.dtype)?;
+                if *tensor.shape() != s {
+                    let msg = format!("shape mismatch for {tensor_name}");
+                    Err(candle::Error::UnexpectedShape {
+                        msg,
+                        expected: s,
+                        got: tensor.shape().clone(),
+                    })?
+                }
+                Ok(tensor)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Merge the different codes together, the llama bit is to be rewritten.
This is pending some rewrite of the var-builder so as to untangle it a bit from safetensors, allow different storage and random initialization (based on hints given by the model, e.g. fan-in, fan-out, glorot, etc).