### PR TITLE
Making multiprocess require flash-attn.

### DIFF
--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -46,4 +46,4 @@ nccl = ["cuda", "cudarc/nccl", "dep:half"]
 
 [[example]]
 name = "llama_multiprocess"
-required-features = ["cuda", "nccl"]
+required-features = ["cuda", "nccl", "flash-attn"]


### PR DESCRIPTION
- Make the necessary changes for `hf-hub 0.2.0` 
- Use `flash_attn` in that example (it's intended to be a powerhouse example, it's OK to no support non flash imo).
- Remove `use_kv_cache`, same logic being slower doesn't seem really interesting to showcase here.
- Remove resulting dead code.
