### PR TITLE
Line-up the llama implementation with the python-transformers one.

### DIFF
--- a/candle-examples/examples/llama_multiprocess/model.rs
+++ b/candle-examples/examples/llama_multiprocess/model.rs
@@ -225,7 +225,7 @@ impl RmsNorm {
         let (b_sz, seq_len, hidden_size) = x.shape().dims3()?;
         let norm_x = (x.sqr()?.sum_keepdim(2)? / hidden_size as f64)?;
         let norm_x = norm_x.broadcast_as((b_sz, seq_len, hidden_size))?;
-        let x_normed = (x / (norm_x + 1e-6)?.sqrt()?)?;
+        let x_normed = (x / (norm_x + 1e-5)?.sqrt()?)?;
         let size = self.scale.shape().dims1()?;
         let scale = self
             .scale


### PR DESCRIPTION
One discrepency was the epsilon used in the layer norm (1e-5 vs 1e-6). After fixing this, logits line up pretty well when using float32/cpu.