### PR TITLE
Remove the embedding ops in favor of index-select.

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -37,7 +37,6 @@ pub trait BackendStorage: Sized {
         _params: &crate::conv::ParamsConv1D,
     ) -> Result<Self>;
 
-    fn embedding(&self, _: &Layout, _: &Self, _: &Layout) -> Result<Self>;
     fn gather(&self, _: &Layout, _: &Self, _: &Layout, _: usize) -> Result<Self>;
     fn scatter_add(
         &self,

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -59,7 +59,6 @@ impl Tensor {
                     | Op::Binary(lhs, rhs, _)
                     | Op::Gather(lhs, rhs, _)
                     | Op::IndexSelect(lhs, rhs, _)
-                    | Op::Embedding(lhs, rhs)
                     | Op::Matmul(lhs, rhs) => {
                         let (tg, nodes) = walk(lhs, nodes, already_seen);
                         track_grad |= tg;
@@ -187,9 +186,6 @@ impl Tensor {
                     Op::IndexSelect(arg, indexes, dim) => {
                         let sum_grad = grads.or_insert(arg)?;
                         *sum_grad = sum_grad.index_add(indexes, &grad, *dim)?;
-                    }
-                    Op::Embedding(_lhs, _rhs) => {
-                        Err(Error::BackwardNotSupported { op: "embedding" })?
                     }
                     Op::Matmul(lhs, rhs) => {
                         // Skipping checks, the op went ok, we can skip

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -75,9 +75,6 @@ impl crate::backend::BackendStorage for CudaStorage {
         Err(Error::NotCompiledWithCudaSupport)
     }
 
-    fn embedding(&self, _: &Layout, _: &Self, _: &Layout) -> Result<Self> {
-        Err(Error::NotCompiledWithCudaSupport)
-    }
     fn index_select(&self, _: &Self, _: &Layout, _: &Layout, _: usize) -> Result<Self> {
         Err(Error::NotCompiledWithCudaSupport)
     }

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -65,7 +65,6 @@ pub enum Op {
     // The third argument is the reduced shape with `keepdim=true`.
     Reduce(Tensor, ReduceOp, Vec<usize>),
     Matmul(Tensor, Tensor),
-    Embedding(Tensor, Tensor),
     Gather(Tensor, Tensor, usize),
     ScatterAdd(Tensor, Tensor, Tensor, usize),
     IndexSelect(Tensor, Tensor, usize),

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -295,26 +295,6 @@ impl Storage {
         }
     }
 
-    pub(crate) fn embedding(&self, layout: &Layout, rhs: &Self, rhs_l: &Layout) -> Result<Self> {
-        self.same_device(rhs, "embedding")?;
-        match (self, rhs) {
-            (Self::Cpu(lhs), Self::Cpu(rhs)) => {
-                let storage = lhs.embedding(layout, rhs, rhs_l)?;
-                Ok(Self::Cpu(storage))
-            }
-            (Self::Cuda(lhs), Self::Cuda(rhs)) => {
-                let storage = lhs.embedding(layout, rhs, rhs_l)?;
-                Ok(Self::Cuda(storage))
-            }
-            (lhs, rhs) => Err(Error::DeviceMismatchBinaryOp {
-                lhs: lhs.device().location(),
-                rhs: rhs.device().location(),
-                op: "embedding",
-            }
-            .bt()),
-        }
-    }
-
     pub(crate) fn gather(
         &self,
         l: &Layout,

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -534,7 +534,7 @@ fn cat(device: &Device) -> Result<()> {
 fn embeddings(device: &Device) -> Result<()> {
     let ids = Tensor::new(&[0u32, 2u32, 1u32], device)?;
     let t = Tensor::new(&[[0f32, 1f32], [2f32, 3f32], [4f32, 5f32]], device)?;
-    let hs = Tensor::embedding(&ids, &t)?;
+    let hs = t.embedding(&ids)?;
     assert_eq!(hs.to_vec2::<f32>()?, &[[0.0, 1.0], [4.0, 5.0], [2.0, 3.0]]);
     let hs = t.index_select(&ids, 0)?;
     assert_eq!(hs.to_vec2::<f32>()?, &[[0.0, 1.0], [4.0, 5.0], [2.0, 3.0]]);

--- a/candle-examples/examples/musicgen/encodec_model.rs
+++ b/candle-examples/examples/musicgen/encodec_model.rs
@@ -142,7 +142,7 @@ impl EncodecEuclideanCodebook {
     }
 
     fn decode(&self, embed_ind: &Tensor) -> Result<Tensor> {
-        let quantize = Tensor::embedding(embed_ind, &self.embed)?;
+        let quantize = self.embed.embedding(embed_ind)?;
         Ok(quantize)
     }
 }

--- a/candle-kernels/src/indexing.cu
+++ b/candle-kernels/src/indexing.cu
@@ -3,32 +3,6 @@
 #include "cuda_utils.cuh"
 #include<stdint.h>
 
-#define EMB_OP(TYPENAME, INDEX_TYPENAME, FN_NAME) \
-extern "C" __global__ void FN_NAME(  \
-    const size_t numel,  \
-    const size_t num_dims, \
-    const size_t *info, \
-    const INDEX_TYPENAME *ids, \
-    const TYPENAME *inp, \
-    TYPENAME *out, \
-    const size_t h_size, \
-    const size_t v_size \
-) {  \
-    const size_t *dims = info; \
-    const size_t *strides = info + num_dims; \
-    if (is_contiguous(num_dims, dims, strides)) { \
-        for (unsigned int i = blockIdx.x * blockDim.x + threadIdx.x; i < numel; i += blockDim.x * gridDim.x) { \
-            memcpy(&out[i * h_size], &inp[ids[i] * h_size], h_size * sizeof(TYPENAME)); \
-        } \
-    } \
-    else { \
-        for (unsigned int i = blockIdx.x * blockDim.x + threadIdx.x; i < numel; i += blockDim.x * gridDim.x) { \
-            unsigned strided_i = get_strided_index(i, num_dims, dims, strides); \
-            memcpy(&out[i * h_size], &inp[ids[strided_i] * h_size], h_size * sizeof(TYPENAME)); \
-        } \
-    } \
-} \
-
 template<typename T, typename I>
 __device__ void index_select(
     const size_t numel,
@@ -177,8 +151,6 @@ extern "C" __global__ void FN_NAME(  \
 
 
 #if __CUDA_ARCH__ >= 800
-EMB_OP(__nv_bfloat16, uint32_t, emb_u32_bf16)
-EMB_OP(__nv_bfloat16, uint8_t, emb_u8_bf16)
 IS_OP(__nv_bfloat16, uint32_t, is_u32_bf16)
 IS_OP(__nv_bfloat16, uint8_t, is_u8_bf16)
 GATHER_OP(__nv_bfloat16, uint32_t, gather_u32_bf16)
@@ -190,8 +162,6 @@ SA_OP(__nv_bfloat16, uint8_t, sa_u8_bf16)
 #endif
 
 #if __CUDA_ARCH__ >= 530
-EMB_OP(__half, uint32_t, emb_u32_f16)
-EMB_OP(__half, uint8_t, emb_u8_f16)
 IS_OP(__half, uint32_t, is_u32_f16)
 IS_OP(__half, uint8_t, is_u8_f16)
 GATHER_OP(__half, uint32_t, gather_u32_f16)
@@ -201,16 +171,6 @@ IA_OP(__half, uint8_t, ia_u8_f16)
 SA_OP(__half, uint32_t, sa_u32_f16)
 SA_OP(__half, uint8_t, sa_u8_f16)
 #endif
-
-EMB_OP(float, uint32_t, emb_u32_f32)
-EMB_OP(double, uint32_t, emb_u32_f64)
-EMB_OP(uint8_t, uint32_t, emb_u32_u8)
-EMB_OP(uint32_t, uint32_t, emb_u32_u32)
-
-EMB_OP(float, uint8_t, emb_u8_f32)
-EMB_OP(double, uint8_t, emb_u8_f64)
-EMB_OP(uint8_t, uint8_t, emb_u8_u8)
-EMB_OP(uint32_t, uint8_t, emb_u8_u32)
 
 IS_OP(float, uint32_t, is_u32_f32)
 IS_OP(double, uint32_t, is_u32_f64)


### PR DESCRIPTION
The embedding op can be obtained via `index_select` with a target dim of 0, the advantage of `index_select` is that backprop is supported so remove the embedding specific op in favor of this and cleanup the related code.